### PR TITLE
Created issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect-report.md
+++ b/.github/ISSUE_TEMPLATE/defect-report.md
@@ -1,0 +1,38 @@
+---
+name: Defect report
+about: Report a defect to help us improve
+title: 'Defect: NAME'
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,60 @@
+---
+name: Epic
+about: Create an epic
+title: 'Epic: NAME'
+labels: ''
+assignees: ''
+
+---
+
+# Template Instructions
+
+Use this template to create a new Epic item.
+
+1. Copy this template and paste it into a new item project item under backlog.
+2. Fill in the placeholders with your own information.
+3. Remove these instructions from the item (the horizontal line and above)
+4. Add any additional details or context that may be helpful.
+5. Assign the issue to a team member or yourself.
+6. Use the checkboxes to track progress and ensure all requirements are met before marking the issue as complete.
+
+---
+
+# <Epic Title>
+
+## User Stories
+
+List the user stories that are associated with this epic.
+
+- [ ] As a ROLE, I want GOAL, so that REASON #link
+- [ ] As a ROLE, I want GOAL, so that REASON #link
+- [ ] As a ROLE, I want GOAL, so that REASON #link
+
+## Technical Requirements
+
+List the technical requirements for this epic.
+
+- [ ] [Requirement 1]
+- [ ] [Requirement 2]
+- [ ] [Requirement 3]
+
+## Design Considerations
+
+List any special design considerations for this epic.
+
+- [ ] [Consideration 1]
+- [ ] [Consideration 2]
+
+## Dependencies
+
+List any epics that this epic depends on.
+
+- [ ] [Epic 1]
+- [ ] [Epic 2]
+
+## Design Documents
+
+List the design documents associated with this epic.
+
+- [ ] [Document 1]
+- [ ] [Document 2]

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -1,0 +1,58 @@
+---
+name: Spike
+about: Create a research spike
+title: 'Spike: NAME'
+labels: ''
+assignees: ''
+
+---
+
+# Template Instructions
+
+Use this template to create a new Spike item.
+
+Note: A Spike in agile development is a time-boxed research or prototyping activity aimed at answering a particular question, reducing technical uncertainty, or exploring a potential solution. It is a way to reduce risk and ensure that you are making informed decisions.
+
+1. Copy this template and paste it into a new item project item under backlog.
+2. Fill in the blanks with your own information.
+3. Remove these instructions from the item (the horizontal line and above).
+4. Assign the issue to a team member or yourself.
+5. Use the checkboxes to track progress and ensure all requirements are met before marking the issue as complete.
+
+---
+
+# <Spike Title>
+
+## Problem Statement
+
+Describe the problem you are trying to solve or the question you are trying to answer in a way that everyone can understand. Try to be clear and concise.
+
+## Goal
+
+What do you want to achieve with this spike? What are you hoping to learn or prove?
+
+## Hypothesis
+
+What is your best guess about how to solve the problem or answer the question? What assumptions are you making?
+
+## Questions
+
+List the specific questions you need to answer to achieve your goal. These should be small, manageable questions that will help you make progress.
+
+- [ ] [Question 1]
+- [ ] [Question 2]
+- [ ] [Question 3]
+
+## Research Tasks
+
+List the specific tasks you need to perform to answer the questions and achieve your goal. These should be small, manageable tasks that will help you make progress.
+
+- [ ] [Task 1]
+- [ ] [Task 2]
+- [ ] [Task 3]
+
+## Results and Conclusion
+
+Summarize the results of your research. What did you learn? What worked? What didn't work? What are the implications of the results?
+
+Based on your results, what is your conclusion? What do you recommend? What is your next step?

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,53 @@
+---
+name: Story
+about: Create a story
+title: 'Story: NAME'
+labels: ''
+assignees: ''
+
+---
+
+# Template Instructions
+
+Use this template to create a new story item.
+
+1. Copy this template and paste it into a new item project item under backlog.
+2. Fill in the placeholders with your own information.
+3. Remove these instructions from the item (the horizontal line and above)
+4. Add any additional details or context that may be helpful.5. Assign the issue to a team member or yourself.
+6. Use the checkboxes to track progress and ensure all requirements are met before marking the issue as complete.
+
+---
+
+# <Story Title>
+
+As a **role**, I want **goal**, so that **reason**.
+
+Associated Epic:
+
+## Definition of Done
+
+- [ ] Acceptance criteria defined
+- [ ] Solution tasks specified
+- [ ] Feature branch created
+- [ ] ~~Unit tests written (on API code only for now)~~
+- [ ] ~~Solution passes full suite of unit tests~~
+- [ ] Design documents updated if needed
+- [ ] Pull request created
+- [ ] Code is reviewed
+- [ ] Code is merged to `develop` branch
+- [ ] ~~Tests pass on CI~~
+- [ ] ~~Deployed to staging environment~~
+- [ ] Acceptance criteria is met
+
+## Acceptance Criteria
+
+- [ ] Given **initial context**, when **event occurs**, then **some desired outcome**
+- [ ] Given **initial context**, when **event occurs**, then **some desired outcome**
+- [ ] Given **initial context**, when **event occurs**, then **some desired outcome**
+
+## Solution Tasks
+
+- [ ] [Task 1]
+- [ ] [Task 2]
+- [ ] [Task 3]

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,39 @@
+---
+name: Task
+about: Create a task item
+title: 'Task: NAME'
+labels: ''
+assignees: ''
+
+---
+
+# Template Instructions
+
+Use this template to create a new task item.
+
+1. Copy this template and paste it into a new item project item under backlog.
+2. Fill in the placeholders with your own information.
+3. Remove these instructions from the item (the horizontal line and above)
+4. Add any additional details or context that may be helpful.
+5. Assign the issue to a team member or yourself.
+6. Use the checkboxes to track progress and ensure all requirements are met before marking the issue as complete.
+
+---
+
+# <Task Title>
+
+## Description
+
+[Add description of the task here]
+
+## Subtasks
+
+- [ ] [Subtask 1]
+- [ ] [Subtask 2]
+- [ ] [Subtask 3]
+
+## Acceptance Criteria
+
+- [ ] [Acceptance Criteria 1]
+- [ ] [Acceptance Criteria 2]
+- [ ] [Acceptance Criteria 3]


### PR DESCRIPTION
Added GitHub issues templates for defect report, epic, story, task, and spike.

With these added, when we create an item on the projects board, we can select the template on the right menu, and the item should auto-populate with the template markdown.