### PR TITLE
Removing "Learn about Accessibility"

### DIFF
--- a/client/src/components/body/landingpage/index.js
+++ b/client/src/components/body/landingpage/index.js
@@ -24,11 +24,8 @@ const Home = (props) => {
       <header className="masthead">
         <div className="container">
           <div className="intro-text">
-            <div className="intro-lead-in">
-              Welcome to the Accessible Learning Labs (ALL) Project!
-            </div>
             <div className="intro-heading text-uppercase">
-              Learn about Accessibility
+              Welcome to the Accessible Learning Labs (ALL)!
             </div>
             <div id="goals" />
           </div>


### PR DESCRIPTION
Krutz wanted aux dev to change the "Learn About Acessibility" tagline since we are moving beyond just accessibility education. I would've liked for "Accessible Learning Labs (ALL)! to be under "Welcome to the" but I had issues with updating the sass file and the client not updating.