### PR TITLE
654 create reusable about us section component

### DIFF
--- a/client/src/components/all-components/ALLButton.js
+++ b/client/src/components/all-components/ALLButton.js
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const ALLButton = (props) => {
+  const { label, onClick, className, type } = props;
+
+  return (
+    <div className={`${className} tw-h-100 tw-m-3`}>
+      <button
+        className={
+          "tw-border-0 tw-relative tw-py-1 tw-px-2 tw-bg-white tw-font-calibri"
+        }
+        onClick={onClick}
+        type={type}
+      >
+        {label}
+        <div
+          className="tw-absolute tw-border-solid tw-border-primary-blue
+                tw-border-[0.4rem] tw-right-[-0.5rem] tw-top-[-0.5rem] tw-h-full tw-w-full tw-z-1
+                tw-border-l-0 tw-border-b-0 tw-rounded-tr-xl"
+        />
+        <div
+          className={
+            "tw-absolute tw-border-solid tw-border-primary-yellow " +
+            "tw-border-[0.4rem] tw-left-[-0.5rem] tw-bottom-[-0.5rem] " +
+            "tw-w-full tw-h-full tw-z-1 tw-border-t-0 tw-border-r-0 tw-rounded-bl-xl"
+          }
+        />
+      </button>
+    </div>
+  );
+};
+
+ALLButton.propTypes = {
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+  className: PropTypes.string,
+  type: PropTypes.string,
+};
+
+export default ALLButton;

--- a/client/src/components/all-components/ALLButton.js
+++ b/client/src/components/all-components/ALLButton.js
@@ -8,7 +8,7 @@ const ALLButton = (props) => {
     <div className={`${className} tw-h-100 tw-m-3`}>
       <button
         className={
-          "tw-border-0 tw-relative tw-py-1 tw-px-2 tw-bg-white tw-font-calibri"
+          "tw-border-0 tw-relative tw-py-1 tw-bg-white tw-font-calibri tw-px-6 xs:tw-text-xs lg:tw-text-[1.125rem]"
         }
         onClick={onClick}
         type={type}
@@ -17,13 +17,13 @@ const ALLButton = (props) => {
         <div
           className="tw-absolute tw-border-solid tw-border-primary-blue
                 tw-border-[0.4rem] tw-right-[-0.5rem] tw-top-[-0.5rem] tw-h-full tw-w-full tw-z-1
-                tw-border-l-0 tw-border-b-0 tw-rounded-tr-xl"
+                tw-border-l-0 tw-border-b-0 tw-rounded-tr-lg"
         />
         <div
           className={
             "tw-absolute tw-border-solid tw-border-primary-yellow " +
             "tw-border-[0.4rem] tw-left-[-0.5rem] tw-bottom-[-0.5rem] " +
-            "tw-w-full tw-h-full tw-z-1 tw-border-t-0 tw-border-r-0 tw-rounded-bl-xl"
+            "tw-w-full tw-h-full tw-z-1 tw-border-t-0 tw-border-r-0 tw-rounded-bl-lg"
           }
         />
       </button>

--- a/client/src/components/all-components/AboutUs.js
+++ b/client/src/components/all-components/AboutUs.js
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from "react";
+import ALLButton from "./ALLButton";
+import { navigate } from "@reach/router";
+const AboutUs = () => {
+  const yellowBlock = useRef(null);
+  const [width, setWidth] = useState(0);
+
+  const handleNav = () => {
+    navigate("/aboutus");
+  };
+
+  useEffect(() => {
+    const changeWidth = () => {
+      if (yellowBlock.current) {
+        setWidth(yellowBlock.current.offsetWidth);
+      }
+    };
+    changeWidth();
+    window.addEventListener("resize", changeWidth);
+  }, []);
+
+  return (
+    <div className={"tw-h-[30rem] tw-w-full"}>
+      <div
+        className={
+          "tw-h-1/2 tw-border-t-[4rem] tw-border-r-[1.5rem] tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-yellow tw-bg-primary-yellow"
+        }
+      >
+        <div
+          className={
+            "tw-h-full tw-flex tw-flex-row tw-justify-center tw-border-t-[.75rem] tw-border-r-[.75rem] tw-rounded-tr-lg tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-blue tw-bg-white"
+          }
+        >
+          <div
+            className={`tw-ml-[2.25rem] tw-flex tw-flex-row tw-text-left`}
+            style={{
+              width: `${width}px`,
+            }}
+          >
+            <div
+              className={
+                "tw-flex tw-flex-col tw-w-1/2 tw-h-full tw-justify-center"
+              }
+            >
+              <p
+                className={
+                  "tw-title-styling-name tw-text-2xl tw-my-3 tw-font-poppins"
+                }
+              >
+                {" "}
+                About Us
+              </p>
+              <p className={"tw-font-calibri tw-font-medium tw-text-sm"}>
+                {" "}
+                Learn more about the team at Accessible Learning Labs and the
+                amazing things we have in the works!
+              </p>
+            </div>
+            <div
+              className={
+                "tw-h-full tw-w-1/2 tw-flex tw-flex-row tw-justify-end tw-items-baseline"
+              }
+            >
+              <ALLButton label={"Learn More"} onClick={handleNav}></ALLButton>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className={"tw-w-full tw-h-1/2 tw-flex tw-flex-row tw-justify-center"}
+      >
+        <div
+          ref={yellowBlock}
+          className={"tw-bg-primary-yellow tw-w-1/2 tw-h-3/4"}
+        >
+          {/*TODO: Placeholder for Stock Image*/}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AboutUs;

--- a/client/src/components/all-components/AboutUs.js
+++ b/client/src/components/all-components/AboutUs.js
@@ -58,7 +58,7 @@ const AboutUs = () => {
             </div>
             <div
               className={
-                "tw-h-full tw-w-1/2 tw-flex tw-flex-row tw-justify-end tw-items-baseline"
+                "tw-h-full tw-w-1/2 tw-flex tw-flex-col tw-justify-end tw-items-end tw-py-5"
               }
             >
               <ALLButton label={"Learn More"} onClick={handleNav}></ALLButton>

--- a/client/src/components/all-components/AboutUs.js
+++ b/client/src/components/all-components/AboutUs.js
@@ -1,56 +1,46 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef } from "react";
 import ALLButton from "./ALLButton";
 import { navigate } from "@reach/router";
 const AboutUs = () => {
   const yellowBlock = useRef(null);
-  const [width, setWidth] = useState(0);
 
   const handleNav = () => {
     navigate("/aboutus");
   };
 
-  useEffect(() => {
-    const changeWidth = () => {
-      if (yellowBlock.current) {
-        setWidth(yellowBlock.current.offsetWidth);
-      }
-    };
-    changeWidth();
-    window.addEventListener("resize", changeWidth);
-  }, []);
-
   return (
-    <div className={"tw-h-[30rem] tw-w-full"}>
+    <div className={"tw-h-[20rem] tw-w-full"}>
       <div
         className={
-          "tw-h-1/2 tw-border-t-[4rem] tw-border-r-[1.5rem] tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-yellow tw-bg-primary-yellow"
+          "tw-h-3/4 xs:tw-flex-col md:tw-flex-row tw-border-t-[4rem] tw-border-r-[1.5rem] tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-yellow tw-bg-primary-yellow"
         }
       >
         <div
           className={
-            "tw-h-full tw-flex tw-flex-row tw-justify-center tw-border-t-[.75rem] tw-border-r-[.75rem] tw-rounded-tr-lg tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-blue tw-bg-white"
+            "tw-h-full tw-flex tw-flex-row tw-justify-center tw-border-t-[.75rem] tw-border-r-[.75rem] tw-rounded-tr-lg tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-blue tw-bg-white tw-p-3"
           }
         >
           <div
-            className={`tw-ml-[2.25rem] tw-flex tw-flex-row tw-text-left`}
-            style={{
-              width: `${width}px`,
-            }}
+            className={`tw-ml-[2.25rem] tw-flex tw-flex-row tw-text-left xs:tw-w-full md:tw-w-1/2`}
           >
             <div
               className={
-                "tw-flex tw-flex-col tw-w-1/2 tw-h-full tw-justify-center"
+                "tw-flex tw-flex-col tw-w-3/4 tw-h-full tw-justify-center"
               }
             >
               <p
                 className={
-                  "tw-title-styling-name tw-text-2xl tw-my-3 tw-font-poppins"
+                  "tw-title-styling-name xs:tw-text-sm md:tw-text-[1.5rem] tw-my-3 tw-font-poppins"
                 }
               >
                 {" "}
                 About Us
               </p>
-              <p className={"tw-font-calibri tw-font-medium tw-text-sm"}>
+              <p
+                className={
+                  "tw-font-calibri tw-font-medium xs:tw-text-sm lg:tw-text-[1.125rem]"
+                }
+              >
                 {" "}
                 Learn more about the team at Accessible Learning Labs and the
                 amazing things we have in the works!
@@ -67,11 +57,13 @@ const AboutUs = () => {
         </div>
       </div>
       <div
-        className={"tw-w-full tw-h-1/2 tw-flex tw-flex-row tw-justify-center"}
+        className={
+          "tw-w-full tw-h-1/2 tw-flex tw-flex-row tw-justify-center xs:tw-collapse md:tw-visible"
+        }
       >
         <div
           ref={yellowBlock}
-          className={"tw-bg-primary-yellow tw-w-1/2 tw-h-3/4"}
+          className={"tw-bg-primary-yellow tw-w-1/2 xs:tw-h-1/2 md:tw-h-3/4"}
         >
           {/*TODO: Placeholder for Stock Image*/}
         </div>

--- a/client/src/components/body/landingpage/index.js
+++ b/client/src/components/body/landingpage/index.js
@@ -10,6 +10,7 @@ import LabGeneration from "../lab/LabGeneration";
 import ProfileGeneration from "./citation/ProfileGeneration";
 import HorizontalLine from "../../../common/HorizontalLine/HorizontalLine";
 import MainFooter from "../../footer/mainFooter";
+import AboutUs from "../../all-components/AboutUs";
 
 const mapDispatchToProps = (dispatch) => {
   return {
@@ -94,7 +95,7 @@ const Home = (props) => {
       </section>
       {/* Team Citation */}
       <div id="citation" />
-
+      <AboutUs />
       <HorizontalLine />
 
       <ProfileGeneration />
@@ -133,6 +134,7 @@ const Home = (props) => {
           </div>
         </div>
       </section>
+
       <MainFooter />
     </div>
   );


### PR DESCRIPTION
## Work Completed
Create reusable, scalable About Us page section component that will be used on other pages across the UI refresh, such as the "Labs" page and "Educator Resources" page.

## Notes
Waiting on Stock images to insert the image.

## QA Checklist
- [ ] No discrepancies across browsers. Eg. chrome vs safari
- [ ] Pages pass W3C Validation for HTML (https://validator.w3.org)
- [ ] CSS (https://jigsaw.w3.org/css-validator/)
- [ ] Google sign-in is operational
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Passes WAVE Evaluation Tool chrome extension
