### PR TITLE
655 create reusable interested in getting involved component

### DIFF
--- a/client/src/components/all-components/ALLButton.js
+++ b/client/src/components/all-components/ALLButton.js
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const ALLButton = (props) => {
+  const { label, onClick, className, type } = props;
+
+  return (
+    <div className={`${className} tw-h-100 tw-m-3`}>
+      <button
+        className={
+          "tw-border-0 tw-relative tw-py-1 tw-px-2 tw-bg-white tw-font-calibri"
+        }
+        onClick={onClick}
+        type={type}
+      >
+        {label}
+        <div
+          className="tw-absolute tw-border-solid tw-border-primary-blue
+                tw-border-[0.4rem] tw-right-[-0.5rem] tw-top-[-0.5rem] tw-h-full tw-w-full tw-z-1
+                tw-border-l-0 tw-border-b-0 tw-rounded-tr-xl"
+        />
+        <div
+          className={
+            "tw-absolute tw-border-solid tw-border-primary-yellow " +
+            "tw-border-[0.4rem] tw-left-[-0.5rem] tw-bottom-[-0.5rem] " +
+            "tw-w-full tw-h-full tw-z-1 tw-border-t-0 tw-border-r-0 tw-rounded-bl-xl"
+          }
+        />
+      </button>
+    </div>
+  );
+};
+
+ALLButton.propTypes = {
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+  className: PropTypes.string,
+  type: PropTypes.string,
+};
+
+export default ALLButton;

--- a/client/src/components/all-components/ALLButton.js
+++ b/client/src/components/all-components/ALLButton.js
@@ -8,7 +8,7 @@ const ALLButton = (props) => {
     <div className={`${className} tw-h-100 tw-m-3`}>
       <button
         className={
-          "tw-border-0 tw-relative tw-py-1 tw-px-2 tw-bg-white tw-font-calibri tw-px-6"
+          "tw-border-0 tw-relative tw-py-1 tw-bg-white tw-font-calibri tw-px-6 xs:tw-text-xs md:tw-text-[1.125rem]"
         }
         onClick={onClick}
         type={type}

--- a/client/src/components/all-components/ALLButton.js
+++ b/client/src/components/all-components/ALLButton.js
@@ -8,7 +8,7 @@ const ALLButton = (props) => {
     <div className={`${className} tw-h-100 tw-m-3`}>
       <button
         className={
-          "tw-border-0 tw-relative tw-py-1 tw-px-2 tw-bg-white tw-font-calibri"
+          "tw-border-0 tw-relative tw-py-1 tw-px-2 tw-bg-white tw-font-calibri tw-px-6"
         }
         onClick={onClick}
         type={type}
@@ -17,13 +17,13 @@ const ALLButton = (props) => {
         <div
           className="tw-absolute tw-border-solid tw-border-primary-blue
                 tw-border-[0.4rem] tw-right-[-0.5rem] tw-top-[-0.5rem] tw-h-full tw-w-full tw-z-1
-                tw-border-l-0 tw-border-b-0 tw-rounded-tr-xl"
+                tw-border-l-0 tw-border-b-0 tw-rounded-tr-lg"
         />
         <div
           className={
             "tw-absolute tw-border-solid tw-border-primary-yellow " +
             "tw-border-[0.4rem] tw-left-[-0.5rem] tw-bottom-[-0.5rem] " +
-            "tw-w-full tw-h-full tw-z-1 tw-border-t-0 tw-border-r-0 tw-rounded-bl-xl"
+            "tw-w-full tw-h-full tw-z-1 tw-border-t-0 tw-border-r-0 tw-rounded-bl-lg"
           }
         />
       </button>

--- a/client/src/components/all-components/AboutUs.js
+++ b/client/src/components/all-components/AboutUs.js
@@ -17,20 +17,20 @@ const AboutUs = () => {
       >
         <div
           className={
-            "tw-h-full tw-flex tw-flex-row tw-justify-center tw-border-t-[.75rem] tw-border-r-[.75rem] tw-rounded-tr-lg tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-blue tw-bg-white tw-p-3"
+            "tw-h-full tw-flex tw-flex-row tw-justify-center tw-border-t-[.75rem] tw-border-r-[.75rem] tw-rounded-tr-lg tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-blue tw-bg-white"
           }
         >
           <div
-            className={`tw-ml-[2.25rem] tw-flex xs:tw-flex-col md:tw-flex-row tw-text-left xs:tw-w-full md:tw-w-1/2`}
+            className={`tw-flex xs:tw-flex-col md:tw-flex-row tw-text-left xs:tw-w-full md:tw-w-1/2 tw-p-3`}
           >
             <div
               className={
-                "tw-flex tw-flex-col tw-w-3/4 tw-h-full tw-justify-center"
+                "tw-flex tw-flex-col xs:tw-w-full lg:tw-w-3/4 tw-h-full tw-justify-center"
               }
             >
               <p
                 className={
-                  "tw-title-styling-name xs:tw-text-sm md:tw-text-[1.5rem] tw-my-3 tw-font-poppins"
+                  "tw-title-styling-name xs:tw-text-sm md:tw-text-[1.5rem] tw-my-6 tw-font-poppins"
                 }
               >
                 {" "}

--- a/client/src/components/all-components/GettingInvolved.js
+++ b/client/src/components/all-components/GettingInvolved.js
@@ -1,0 +1,68 @@
+import React from "react";
+import ALLButton from "./ALLButton";
+import { navigate } from "@reach/router";
+const GettingInvolved = () => {
+  const handleNav = () => {
+    navigate("/#contact");
+  };
+
+  return (
+    <div className={"tw-h-[25rem] tw-w-full"}>
+      <div
+        className={
+          "tw-h-1/2 tw-border-t-[4rem] tw-border-r-[1.5rem] tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-yellow tw-bg-primary-yellow"
+        }
+      >
+        <div
+          className={
+            "tw-h-full tw-flex tw-flex-row tw-justify-center tw-align-middle tw-border-t-[.75rem] tw-border-r-[.75rem] tw-rounded-tr-lg tw-border-b-0 tw-border-l-0 tw-border-solid tw-border-primary-blue tw-bg-white"
+          }
+        >
+          <div
+            className={`tw-flex tw-flex-row tw-text-left sm:tw-w-full lg:tw-w-1/2`}
+          >
+            <div
+              className={
+                "tw-flex tw-flex-col tw-w-full tw-h-full tw-justify-center tw-m-[3rem]"
+              }
+            >
+              <p
+                className={
+                  "tw-title-styling-name xxs:tw-text-sm md:lg:tw-text-2xl tw-my-3 tw-font-poppins md:lg:tw-w-1/2"
+                }
+              >
+                {" "}
+                Interested in Getting Involved?
+              </p>
+              <div className={"tw-flex tw-flex-row  tw-items-center"}>
+                <p
+                  className={
+                    "tw-font-calibri tw-font-medium sm:tw-text-sm xs:tw-text-xs"
+                  }
+                >
+                  {" "}
+                  Whether you want to implement our labs in your course
+                  curriculum, join the Accessible Learning Labs development
+                  partners or anything in between, you can click here to learn
+                  more!
+                </p>
+                <div
+                  className={
+                    "tw-h-full tw-w-full tw-flex tw-flex-row tw-justify-end tw-py-5"
+                  }
+                >
+                  <ALLButton
+                    label={"Learn More"}
+                    onClick={handleNav}
+                  ></ALLButton>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GettingInvolved;

--- a/client/src/components/all-components/GettingInvolved.js
+++ b/client/src/components/all-components/GettingInvolved.js
@@ -19,7 +19,7 @@ const GettingInvolved = () => {
           }
         >
           <div
-            className={`tw-flex tw-flex-row tw-text-left sm:tw-w-full md:tw-w-3/4 lg:tw-w-1/2`}
+            className={`tw-flex tw-flex-row tw-text-left sm:tw-w-full md:tw-w-3/4 lg:tw-w-3/5`}
           >
             <div
               className={
@@ -36,12 +36,12 @@ const GettingInvolved = () => {
               </p>
               <div
                 className={
-                  "tw-flex xs:tw-flex-col md:tw-flex-row tw-items-center"
+                  "tw-flex xs:tw-flex-col lg:tw-flex-row tw-items-center"
                 }
               >
                 <p
                   className={
-                    "tw-font-calibri tw-font-medium sm:tw-text-[1.125rem] xs:tw-text-xs"
+                    "tw-font-calibri tw-font-medium sm:tw-text-sm md:tw-text-[1.125rem] xs:tw-text-xs tw-text-justify"
                   }
                 >
                   {" "}

--- a/client/src/components/all-components/GettingInvolved.js
+++ b/client/src/components/all-components/GettingInvolved.js
@@ -19,7 +19,7 @@ const GettingInvolved = () => {
           }
         >
           <div
-            className={`tw-flex tw-flex-row tw-text-left sm:tw-w-full lg:tw-w-1/2`}
+            className={`tw-flex tw-flex-row tw-text-left sm:tw-w-full md:tw-w-3/4 lg:tw-w-1/2`}
           >
             <div
               className={
@@ -28,16 +28,20 @@ const GettingInvolved = () => {
             >
               <p
                 className={
-                  "tw-title-styling-name xxs:tw-text-sm md:lg:tw-text-2xl tw-my-3 tw-font-poppins md:lg:tw-w-1/2"
+                  "tw-title-styling-name xxs:tw-text-sm md:tw-text-[1.5rem] tw-my-3 tw-font-poppins xs:tw-w-full md:tw-w-3/4"
                 }
               >
                 {" "}
                 Interested in Getting Involved?
               </p>
-              <div className={"tw-flex tw-flex-row  tw-items-center"}>
+              <div
+                className={
+                  "tw-flex xs:tw-flex-col md:tw-flex-row tw-items-center"
+                }
+              >
                 <p
                   className={
-                    "tw-font-calibri tw-font-medium sm:tw-text-sm xs:tw-text-xs"
+                    "tw-font-calibri tw-font-medium sm:tw-text-[1.125rem] xs:tw-text-xs"
                   }
                 >
                   {" "}

--- a/client/src/components/all-components/GettingInvolved.js
+++ b/client/src/components/all-components/GettingInvolved.js
@@ -28,7 +28,7 @@ const GettingInvolved = () => {
             >
               <p
                 className={
-                  "tw-title-styling-name xxs:tw-text-sm md:tw-text-[1.25rem] lg:tw-text-[1.5rem] tw-my-6 tw-font-poppins xs:tw-w-full md:tw-w-3/4 "
+                  "tw-title-styling-name xxs:tw-text-sm md:tw-text-[1.25rem] lg:tw-text-[1.5rem] tw-my-6 tw-font-poppins xs:tw-w-full md:tw-w-3/4 tw-text-nowrap"
                 }
               >
                 {" "}

--- a/client/src/components/all-components/GettingInvolved.js
+++ b/client/src/components/all-components/GettingInvolved.js
@@ -28,7 +28,7 @@ const GettingInvolved = () => {
             >
               <p
                 className={
-                  "tw-title-styling-name xxs:tw-text-sm md:tw-text-[1.5rem] tw-my-3 tw-font-poppins xs:tw-w-full md:tw-w-3/4"
+                  "tw-title-styling-name xxs:tw-text-sm md:tw-text-[1.25rem] lg:tw-text-[1.5rem] tw-my-3 tw-font-poppins xs:tw-w-full md:tw-w-3/4"
                 }
               >
                 {" "}

--- a/client/src/components/all-components/GettingInvolved.js
+++ b/client/src/components/all-components/GettingInvolved.js
@@ -19,7 +19,7 @@ const GettingInvolved = () => {
           }
         >
           <div
-            className={`tw-flex tw-flex-row tw-text-left sm:tw-w-full md:tw-w-3/4 lg:tw-w-3/5`}
+            className={`tw-flex tw-flex-row tw-text-left sm:tw-w-full md:tw-w-3/4 lg:tw-w-3/5 tw-p-6 tw-min-h-[10rem]`}
           >
             <div
               className={

--- a/client/src/components/body/landingpage/index.js
+++ b/client/src/components/body/landingpage/index.js
@@ -10,6 +10,7 @@ import LabGeneration from "../lab/LabGeneration";
 import ProfileGeneration from "./citation/ProfileGeneration";
 import HorizontalLine from "../../../common/HorizontalLine/HorizontalLine";
 import MainFooter from "../../footer/mainFooter";
+import GettingInvolved from "../../all-components/GettingInvolved";
 
 const mapDispatchToProps = (dispatch) => {
   return {
@@ -94,7 +95,7 @@ const Home = (props) => {
       </section>
       {/* Team Citation */}
       <div id="citation" />
-
+      <GettingInvolved />
       <HorizontalLine />
 
       <ProfileGeneration />


### PR DESCRIPTION
## Work Completed
Built out scalable, reusable component for the Getting Involved sections that are seen throughout the ui refresh.

- [ ] No discrepancies across browsers. Eg. chrome vs safari
- [ ] Pages pass W3C Validation for HTML (https://validator.w3.org)
- [ ] CSS (https://jigsaw.w3.org/css-validator/)
- [ ] Google sign-in is operational
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Passes WAVE Evaluation Tool chrome extension
