### PR TITLE
1086 defect lab 11 fog index

### DIFF
--- a/client/src/components/exercise/lab11/components/FogIndexOverlay.js
+++ b/client/src/components/exercise/lab11/components/FogIndexOverlay.js
@@ -65,7 +65,7 @@ const FogIndexOverlay = ({
             Complex Words: {totalComplexWords}
           </div>
           <div className={`tw-body-text tw-font-bold tw-self-start tw-py-2`}>
-            Fog Index: {fogIndex}
+            Fog Index: {fogIndex == Infinity ? 0 : fogIndex}
           </div>
         </div>
       </div>

--- a/client/src/components/exercise/lab11/helpers/FogIndexCalculation.js
+++ b/client/src/components/exercise/lab11/helpers/FogIndexCalculation.js
@@ -45,7 +45,8 @@ const countSyllables = (word) => {
 const fogIndexCalculation = (letterContent, words, sentences, complexWords) => {
   let fogIndex = 0;
   letterContent = letterContent.trim();
-  let wordCount = words ? letterContent.split(" ").length : 0;
+  let wordCount =
+    words && letterContent.length !== 0 ? letterContent.split(" ").length : 0;
   let sentenceCount = sentences ? letterContent.split(/[.!?]/).length - 1 : 0;
   let complexWordCount = complexWords
     ? letterContent.split(" ").filter((word) => countSyllables(word) > 3).length
@@ -62,9 +63,7 @@ const fogIndexCalculation = (letterContent, words, sentences, complexWords) => {
       ? 1
       : 0;
 
-  if (letterContent.length === 0) {
-    wordCount = 0;
-  } else {
+  if (letterContent.length !== 0 && wordCount !== 0 && sentenceCount !== 0) {
     fogIndex = (
       0.4 *
       (wordCount / sentenceCount + 100 * (complexWordCount / wordCount))

--- a/client/src/components/exercise/lab11/helpers/FogIndexCalculation.js
+++ b/client/src/components/exercise/lab11/helpers/FogIndexCalculation.js
@@ -63,7 +63,7 @@ const fogIndexCalculation = (letterContent, words, sentences, complexWords) => {
       ? 1
       : 0;
 
-  if (letterContent.length !== 0 && wordCount !== 0 && sentenceCount !== 0) {
+  if (letterContent.length !== 0) {
     fogIndex = (
       0.4 *
       (wordCount / sentenceCount + 100 * (complexWordCount / wordCount))


### PR DESCRIPTION
- Computes fog index as Infinity due to divide by zero, but displays as 0
- Initial word/sentence/complex word count remain incorrect because they are to be fixed by the user
- Moved setting word count to 0 if the letter is empty to initial declaration

- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)