### PR TITLE
1139 defect fix lab reading links styling

### DIFF
--- a/client/src/assets/stylesheets/components/App.scss
+++ b/client/src/assets/stylesheets/components/App.scss
@@ -147,13 +147,15 @@ li {
   text-decoration: underline;
   padding-right: 10px;
   padding-left: 10px;
+  text-align: center;
+  align-items: center;
 }
 
 .link-footer {
   display: flex;
   justify-content: center;
   margin-bottom: 1rem;
-  flex-direction: column;
+  flex-wrap: wrap;
   align-items: center;
 }
 
@@ -272,12 +274,6 @@ li {
 
 .RepairHeader {
   background: linear-gradient(to right, #414141, #d3d3d3, #fff);
-}
-
-.link {
-  text-decoration: underline;
-  padding-right: 10px;
-  padding-left: 10px;
 }
 
 .playthrough__sentence__imagine {

--- a/client/src/assets/stylesheets/components/App.scss
+++ b/client/src/assets/stylesheets/components/App.scss
@@ -157,6 +157,11 @@ li {
   align-items: center;
 }
 
+.footer-header {
+  margin: 0rem;
+  margin-bottom: 1.25rem;
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0deg);
@@ -273,14 +278,6 @@ li {
   text-decoration: underline;
   padding-right: 10px;
   padding-left: 10px;
-}
-
-.link-footer {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 1rem;
-  flex-direction: column;
-  align-items: center;
 }
 
 .playthrough__sentence__imagine {

--- a/client/src/components/body/Reading/LinkFooter.jsx
+++ b/client/src/components/body/Reading/LinkFooter.jsx
@@ -9,7 +9,7 @@ import React from "react";
 const LinkFooter = ({ data }) => {
   return (
     <>
-      <h4 className="tw-body-text tw-leading-snug xs:tw-text-s md:tw-text-[1.125rem] tw-m-0 tw-mb-5">
+      <h4 className="footer-header tw-body-text tw-leading-snug xs:tw-text-s md:tw-text-[1.125rem]">
         For more information, please visit the following websites:
       </h4>
       <div className="link-footer">

--- a/client/src/components/body/Reading/LinkFooter.jsx
+++ b/client/src/components/body/Reading/LinkFooter.jsx
@@ -9,7 +9,7 @@ import React from "react";
 const LinkFooter = ({ data }) => {
   return (
     <>
-      <h4 className="footerlink tw-body-text xs:tw-text-xs md:tw-text-[1.125rem] tw-leading-snug">
+      <h4 className="tw-body-text tw-leading-snug xs:tw-text-s md:tw-text-[1.125rem] tw-m-0 tw-mb-5">
         For more information, please visit the following websites:
       </h4>
       <div className="link-footer">


### PR DESCRIPTION
- "For more information..." block at the end of all reading sections has been moved to align with the rest of the reading
- All hyperlinks are grouped in horizontal lines instead of sometimes being horizontally grouped and other times vertically grouped on large viewports.
- Long hyperlinks on smaller viewports wrap to the center instead of wrapping to the left.
- Removed duplicate classes in App.scss 


- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)