### PR TITLE
1138 defect labs page not ordered by lab number

### DIFF
--- a/client/src/pages/labspage/LabsPage.js
+++ b/client/src/pages/labspage/LabsPage.js
@@ -82,10 +82,6 @@ const LabsPage = (props) => {
   const [myLabs, setMyLabs] = useState([]);
 
   useEffect(() => {
-    if (labInformation.size !== 0) {
-      return;
-    }
-
     async function fetchGroups() {
       return LabService.getAllLabs();
     }
@@ -103,7 +99,7 @@ const LabsPage = (props) => {
       });
       setLabInformation(hashmap);
     });
-  });
+  }, []);
 
   const labsByDifficulty = (labMap, difficulty) => {
     const filteredMap = new Map();

--- a/server/services/LabService.js
+++ b/server/services/LabService.js
@@ -19,6 +19,7 @@ const quizNotRetrieved = 'Error: Quiz Not Retrieved';
 async function getAllLabs() {
   return await db.Labs.findAll({
     raw: true,
+    order: [['id', 'ASC']],
   });
 };
 /**


### PR DESCRIPTION
- Added the where clause to the query when pulling all the labs from the database
- Cleaned up the useEffect hook on the labPage to run once instead of running always and failing after an if statement

- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)