### PR TITLE
CRITICAL: Fixed crash in Lab 4 repair

### DIFF
--- a/client/src/components/exercise/lab4/pages/CodeChangeTarget.js
+++ b/client/src/components/exercise/lab4/pages/CodeChangeTarget.js
@@ -82,7 +82,7 @@ function MySnackbarContentWrapper(props) {
           onClick={onClose}
           size="large"
         >
-          <CloseIcon className={classes.icon} />
+          <CloseIcon className={clsx(classes.icon)} />
         </IconButton>,
       ]}
       {...other}
@@ -278,11 +278,13 @@ const CodeChangeTarget = () => {
         autoHideDuration={6000}
         onClose={handleClose}
       >
-        <MySnackbarContentWrapper
-          onClose={handleClose}
-          variant="warning"
-          message={state.message}
-        />
+        <div>
+          <MySnackbarContentWrapper
+            onClose={handleClose}
+            variant="warning"
+            message={state.message}
+          />
+        </div>
       </Snackbar>
     </div>
   );


### PR DESCRIPTION
Fixed the first repair crashing when entering invalid/unexpected inputs. Examples:
- Too high of a number ("300")
- Non-numerics ("ajdjsadnasd")
This was most likely caused by an MUI update/upstream change that affected the Snackbar/Toast messages on invalid inputs.

- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)