### PR TITLE
Fix Multi-Select Quiz Answer Color

### DIFF
--- a/client/src/assets/stylesheets/main.css
+++ b/client/src/assets/stylesheets/main.css
@@ -3553,9 +3553,9 @@ a.skip-main:active {
 
 .quiz .checkboxCustomButton:checked ~ .checkboxCustomLabel:before {
   content: "";
-  background: #8bc53f no-repeat;
+  background: #0d28bc no-repeat;
   background-size: 27px;
-  border-color: #8bc53f;
+  border-color: #0d28bc;
 }
 
 .quiz .checkboxCustomButton:checked ~ .checkboxCustomLabel:after {
@@ -3603,9 +3603,9 @@ a.skip-main:active {
 
 .quiz .radioCustomButton:checked ~ .radioCustomLabel:before {
   content: "";
-  background: #8bc53f no-repeat;
+  background: #0d28bc no-repeat;
   background-size: 27px;
-  border-color: #8bc53f;
+  border-color: #0d28bc;
 }
 
 .quiz .radioCustomButton:checked ~ .radioCustomButton:after {

--- a/client/src/assets/stylesheets/pages/quiz.css
+++ b/client/src/assets/stylesheets/pages/quiz.css
@@ -122,9 +122,9 @@
 
 .quiz .checkboxCustomButton:checked ~ .checkboxCustomLabel:before {
   content: "";
-  background: #8bc53f no-repeat;
+  background: #0d28bc no-repeat;
   background-size: 27px;
-  border-color: #8bc53f;
+  border-color: #0d28bc;
 }
 
 .quiz .checkboxCustomButton:checked ~ .checkboxCustomLabel:after {
@@ -172,9 +172,9 @@
 
 .quiz .radioCustomButton:checked ~ .radioCustomLabel:before {
   content: "";
-  background: #8bc53f no-repeat;
+  background: #0d28bc no-repeat;
   background-size: 27px;
-  border-color: #8bc53f;
+  border-color: #0d28bc;
 }
 
 .quiz .radioCustomButton:checked ~ .radioCustomButton:after {

--- a/client/src/assets/stylesheets/pages/quiz.scss
+++ b/client/src/assets/stylesheets/pages/quiz.scss
@@ -123,9 +123,9 @@
 
   .checkboxCustomButton:checked ~ .checkboxCustomLabel:before {
     content: "";
-    background: #8bc53f no-repeat;
+    background: #0d28bc no-repeat;
     background-size: 27px;
-    border-color: #8bc53f;
+    border-color: #0d28bc;
   }
 
   .checkboxCustomButton:checked ~ .checkboxCustomLabel:after {

--- a/client/src/components/exercise/lab14/pages/RSAEncryption.js
+++ b/client/src/components/exercise/lab14/pages/RSAEncryption.js
@@ -121,7 +121,7 @@ const RSAEncryption = () => {
     } catch (err) {
       // On some older systems, the 'crypto' library doesn't have full compatibility.
       // Instead of *actually* doing RSA, we fake it and just shuffle some numbers.
-      
+
       let publicKey =
         "69d8e47ce6873023aa78cfe7d7e0f93f5276fc3f704872b072a49e5c5c5a8480545bc614ff2ddcb8cf157b2500bb2695f2beaa1df4a55d25c985a7a6c6d48603c34cf67b717a31832d141ab485b78935fc6231d231cc987680ba8855a5d4505363323882c256abec86839466ef45194837f09e3c07f675b4b792524eba1b14cef21ffa2fad22d158851419167cc6ff4b166951c7645ff1bcf96f4c281f76a05fcb57c3eb9b8e93b13e87d04edebe6fed";
       let n =

--- a/client/src/components/exercise/lab6/components/App.css
+++ b/client/src/components/exercise/lab6/components/App.css
@@ -109,9 +109,9 @@ body {
 
 .radioCustomButton:checked ~ .radioCustomLabel:before {
   content: "";
-  background: #8bc53f no-repeat;
+  background: #0d28bc no-repeat;
   background-size: 27px;
-  border-color: #8bc53f;
+  border-color: #0d28bc;
 }
 
 /* Animation */


### PR DESCRIPTION
Test with any multi-select quiz question: the selected square should now be blue instead of green.

- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)