### PR TITLE
hotfix-lab4-exercice-crash

### DIFF
--- a/client/src/components/exercise/lab4/pages/CodeChangeBlocks.js
+++ b/client/src/components/exercise/lab4/pages/CodeChangeBlocks.js
@@ -140,7 +140,7 @@ const CodeChangeBlocks = () => {
   useEffect(() => {
     actions.updateUserState(EXERCISE_PLAYING);
     Prism.highlightAll();
-    if (window.location.state.role !== undefined) {
+    if (window.location.state?.role !== undefined) {
       const el0 = document.getElementById("first");
       el0.value = window.location.state.role;
       doEvent(el0, "input");


### PR DESCRIPTION
Lab4/Exercise/CodeChangeBlocks doesn't crash if refreshing or viewing inside devtools

- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)