### PR TITLE
Fixed piechart alt text

### DIFF
--- a/client/src/components/body/Reading/Reading.js
+++ b/client/src/components/body/Reading/Reading.js
@@ -236,12 +236,14 @@ const Reading = (props) => {
               data[0].reading.piechart.data.labels,
             );
           }
+
+          createAccessiblePieLabel(
+            data[0].reading.piechart.data.labels,
+            data[0].reading.piechart.data.datasets[0].data,
+            data[0].reading.piechart.header,
+          );
         }
-        createAccessiblePieLabel(
-          data[0].reading.piechart.data.labels,
-          data[0].reading.piechart.data.datasets[0].data,
-          data[0].reading.piechart.header,
-        );
+
         setReadingData(data[0].reading);
       });
 


### PR DESCRIPTION
Lab13 and Lab14 were breaking on ball because those labs do not have a piechart, and the previous alt text addition did not account for that, causing an error to be thrown on those pages.

- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)