### PR TITLE
Change top spacing for nav pane

### DIFF
--- a/client/src/components/all-components/Lab/LabWindow.js
+++ b/client/src/components/all-components/Lab/LabWindow.js
@@ -54,7 +54,7 @@ const LabWindow = (props) => {
               "tw-col-start-1 md:tw-col-span-3 xl:tw-col-span-2 tw-mx-2 tw-pt-8"
             }
           >
-            <div className={"tw-sticky tw-top-[7.75rem]"}>
+            <div className={"tw-sticky tw-top-[2rem]"}>
               <NavigationPane
                 labID={lab}
                 title={title}

--- a/client/src/components/all-components/Lab/LabWindow.js
+++ b/client/src/components/all-components/Lab/LabWindow.js
@@ -54,7 +54,7 @@ const LabWindow = (props) => {
               "tw-col-start-1 md:tw-col-span-3 xl:tw-col-span-2 tw-mx-2 tw-pt-8"
             }
           >
-            <div className={"tw-sticky tw-top-[2rem]"}>
+            <div className={"tw-sticky tw-top-[9.75rem]"}>
               <NavigationPane
                 labID={lab}
                 title={title}


### PR DESCRIPTION
- Only affects viewports that cannot display the full NavigationPane while in a lab
- Made sure NavigationPane does not move at all while scrolling

- [ ] No discrepancies across browsers (ex: chrome vs safari)
- [ ] Accessibility functions
- [ ] Pages can scale without distorting page
- [ ] No dead links
- [ ] Navbar is consistent across the site
- [ ] Pages are screen-reader accessible
- [ ] Contrast meets standards for accessibility
- [ ] Pages are keyboard accessible
- [ ] Code is cleaned up and bug-free (ex: debug statements removed)